### PR TITLE
Fixed first timer showing, no longer waiting interval

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -24,6 +24,7 @@ Timera.prototype.showTimer = function (){
 }
 
 myTimer = new Timera(targetDate, "days", "hours", "minutes", "seconds");
+myTimer.showTimer() // First run, no need to wait for `setInterval`
 
 setInterval(
   function(){ myTimer.showTimer() }


### PR DESCRIPTION
Issue: #6 
Now, as soon as JavaScript loads, the account starts without waiting for the one second timer.